### PR TITLE
Update .env with a valid testnet obser image

### DIFF
--- a/rosetta-testnet/.env
+++ b/rosetta-testnet/.env
@@ -18,5 +18,5 @@ IP_1=10.0.0.5
 IP_2=10.0.0.4
 IP_M=10.0.0.3
 
-NODE_TAG=elrond-rosetta-observer-testnet:v1.1.10
+NODE_TAG=elrond-rosetta-observer-testnet:v1.1.6
 PROXY_TAG=elrond-rosetta-proxy-testnet:v1.1.3


### PR DESCRIPTION
As of now `docker pull elrondnetwork/elrond-rosetta-observer-testnet:v1.1.10` fails for now a temp fix is to downgrade to an existing image.